### PR TITLE
create an optional check_status_command variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ The default values for the variables are set in `defaults/main.yml`:
 #     secondary_private_ip: "192.168.1.2"
 #   # `virtual_router_id` is the unique identifier.
 #     virtual_router_id: 51
-#   # `priority` is the advertised priority.
+#   # `priority` is the advertised priority. If check_status_command is set, do not set priority over 252 
 #     priority: 255
+#   # `check_status_command` will make +3 to priority if command return is 0. (optional)
+#     check_status_command: /sbin/postfix status
 #   # `authentication` specifies the information necessary for servers participating in VRRP to authenticate with each other.
 #     authentication:
 #       auth_type: PASS

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,8 @@
 #     virtual_router_id: 51
 #   # `priority` is the advertised priority.
 #     priority: 255
+#   # `check_status_command` will make +3 to priority if command return is 0 (optional). example:
+#     check_status_command: /sbin/postfix status
 #   # `authentication` specifies the information necessary for servers participating in VRRP to authenticate with each other.
 #     authentication:
 #       auth_type: PASS

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -1,6 +1,15 @@
 {{ ansible_managed | comment }}
 
 {% for instance in keepalived_vrrp_instances %}
+{% if instance.check_status_command is defined %}
+
+vrrp_script chk_command_{{ instance.virtual_router_id }} {
+   script "{{ instance.check_status_command }} "   # verify the pid existance
+   interval 2                    # check every 2 seconds
+   weight 3                      # add 2 points of prio if OK
+}
+
+{% endif %}
 vrrp_instance {{ instance.name }} {
   state {{ instance.state }}
   interface {{ instance.interface }}
@@ -20,5 +29,10 @@ vrrp_instance {{ instance.name }} {
   {{ ip.name }}/{{ ip.cidr }}
 {% endfor %}
   }
+{% if instance.check_status_command is defined %}
+  track_script {
+    chk_command_{{ instance.virtual_router_id }}
+}
+{% endif %}
 {% endfor %}
 }

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -4,9 +4,9 @@
 {% if instance.check_status_command is defined %}
 
 vrrp_script chk_command_{{ instance.virtual_router_id }} {
-   script "{{ instance.check_status_command }} "   # verify the pid existance
+   script "{{ instance.check_status_command }} "   # command that verify status 
    interval 2                    # check every 2 seconds
-   weight 3                      # add 2 points of prio if OK
+   weight 3                      # add 3 points of prio if OK
 }
 
 {% endif %}


### PR DESCRIPTION
This PR aims to have an optional parameters called "check_status_command".
This parameter must be bash command that returns 0 when ok (eg. "postfix status" return 0 when postfix is kindly working).
If 0, 3 points will be added to priority. 
If other, none is added.

The constraints are : 
- there must be a maximal difference of 2 points between nodes' priority
the priority should not exceed 252 because max priority in keepalived is 255 