### PR TITLE
"enable_security_script" and "script_user" are required in global_defs to run vrrp_script

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ The default values for the variables are set in [`defaults/main.yml`](https://gi
 #     priority: 255
 #   # `check_status_command` will make +3 to priority if command return is 0 (optional). example:
 #     check_status_command: /sbin/postfix status
-#   # `user_script` is used to securely run check_status_command
-#     user_script: haproxy
 #   # `authentication` specifies the information necessary for servers participating in VRRP to authenticate with each other.
 #     authentication:
 #       auth_type: PASS
@@ -96,6 +94,8 @@ The default values for the variables are set in [`defaults/main.yml`](https://gi
 #     virtual_ipaddresses:
 #       - name: "192.168.122.200"
 #         cidr: 24
+# # `keepalived_vrrp_user_script` is used to securely run check_status_command
+# keepalived_vrrp_user_script: haproxy
 keepalived_vrrp_instances: []
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ The default values for the variables are set in [`defaults/main.yml`](https://gi
 #     priority: 255
 #   # `check_status_command` will make +3 to priority if command return is 0 (optional). example:
 #     check_status_command: /sbin/postfix status
+#   # `user_script` is used to securely run check_status_command
+#     user_script: haproxy
 #   # `authentication` specifies the information necessary for servers participating in VRRP to authenticate with each other.
 #     authentication:
 #       auth_type: PASS

--- a/tasks/assert_instances.yml
+++ b/tasks/assert_instances.yml
@@ -54,7 +54,7 @@
     that:
       - item.check_status_command is string
       - item.priority <= 252
-      - item.user_script is string
+      - keepalived_vrrp_user_script is string
     quiet: yes
   when:
     - item.check_status_command is defined

--- a/tasks/assert_instances.yml
+++ b/tasks/assert_instances.yml
@@ -54,6 +54,7 @@
     that:
       - item.check_status_command is string
       - item.priority <= 252
+      - item.user_script is string
     quiet: yes
   when:
     - item.check_status_command is defined

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -37,7 +37,7 @@ vrrp_instance {{ instance.name }} {
 }
 {% endfor %}
 
-{% if cnt[0] > 1 %}
+{% if cnt[0] > 0 %}
 global_defs {
   script_user {{ instance.user_script }} 
   enable_script_security

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -39,7 +39,7 @@ vrrp_instance {{ instance.name }} {
 
 {% if cnt[0] > 0 %}
 global_defs {
-  script_user {{ instance.user_script }} 
+  script_user {{ keepalived_vrrp_user_script }} 
   enable_script_security
 }
 {% endif %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -1,11 +1,5 @@
 {{ ansible_managed | comment }}
-
-global_defs {
-{% if instance.check_status_command is defined %}
-  enable_script_security
-{% endif %}
-}
-
+{% set cnt = [0] %}
 {% for instance in keepalived_vrrp_instances %}
 {% if instance.check_status_command is defined %}
 
@@ -14,7 +8,7 @@ vrrp_script chk_command_{{ instance.virtual_router_id }} {
    interval 2                    # check every 2 seconds
    weight 3                      # add 3 points of prio if OK
 }
-
+{% if cnt.append(cnt.pop() + 1) %}{% endif %} 
 {% endif %}
 vrrp_instance {{ instance.name }} {
   state {{ instance.state }}
@@ -42,3 +36,10 @@ vrrp_instance {{ instance.name }} {
 {% endif %}
 }
 {% endfor %}
+
+{% if cnt[0] > 1 %}
+global_defs {
+  script_user {{ instance.user_script }} 
+  enable_script_security
+}
+{% endif %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -1,5 +1,11 @@
 {{ ansible_managed | comment }}
 
+global_def {
+{% if instance.check_status_command is defined %}
+  enable_script_security
+{% endif %}
+}
+
 {% for instance in keepalived_vrrp_instances %}
 {% if instance.check_status_command is defined %}
 

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -1,6 +1,6 @@
 {{ ansible_managed | comment }}
 
-global_def {
+global_defs {
 {% if instance.check_status_command is defined %}
   enable_script_security
 {% endif %}


### PR DESCRIPTION
 due to keepalived changes, it requires enable_security_script to run vrrp_script and a specific user to run the tests. So added condition in template, assert that user is in table and update README.