### PR TITLE
2.4.3 - initial support for global_defs, virtual routes, and notify_*

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,6 +6,9 @@
 
   roles:
     - role: ansible-role-keepalived
+      keepalived_global_defs:
+        enable_script_security: true
+        script_user: nobody
       keepalived_vrrp_instances:
         - name: VI_1
           state: MASTER
@@ -20,3 +23,14 @@
           virtual_ipaddresses:
             - name: "172.17.0.8"
               cidr: 16
+          virtual_routes:
+            - dest: "192.168.10.1"
+              via: "172.17.0.1"
+              src: "172.17.0.8"
+              dev: eth0
+            - dest: "172.17.0.77"
+              src: "172.17.0.8"
+              dev: eth0
+          notify_master: '"/usr/sbin/service haproxy start" root'
+          notify_backup: '"/usr/sbin/service haproxy stop" root'
+          notify_stop: '"/usr/sbin/service haproxy stop" root'

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -1,4 +1,13 @@
 ---
+- name: assert | Test keepalived_global_defs if defined
+  ansible.builtin.assert:
+    that:
+      - keepalived_global_defs is defined
+      - keepalived_global_defs is mapping
+      - keepalived_global_defs.enable_script_security is undefined or keepalived_global_defs.enable_script_security is boolean
+      - keepalived_global_defs.script_user is undefined or keepalived_global_defs.script_user is string
+    quiet: true
+  when: keepalived_global_defs is defined
 
 - name: assert | Test keepalived_vrrp_instances
   ansible.builtin.assert:
@@ -27,6 +36,9 @@
       - item.priority is number
       - item.priority >= 1
       - item.priority <= 255
+      - item.notify_master is undefined or item.notify_master is string
+      - item.notify_backup is undefined or item.notify_backup is string
+      - item.notify_stop is undefined or item.notify_stop is string
     quiet: true
   loop: "{{ keepalived_vrrp_instances }}"
   loop_control:

--- a/tasks/assert_instances.yml
+++ b/tasks/assert_instances.yml
@@ -35,6 +35,29 @@
   loop_control:
     label: "{{ item.name }}"
 
+- name: assert_instances | Test item in instance.virtual_routes
+  ansible.builtin.assert:
+    that:
+      - item | length > 2
+      - item | length <= 4
+      - item.dest is defined
+      - item.dest is string
+      - item.dest | length >= 8
+      - item.dest | length <= 16
+      - item.via is undefined or item.via is string
+      - item.via is undefined or item.via| length >= 8
+      - item.via is undefined or item.via | length <= 16
+      - item.src is defined
+      - item.src is string
+      - item.src | length >= 8
+      - item.src | length <= 16
+      - item.dev is defined
+      - item.dev is string
+    quiet: true
+  loop: "{{ instance.virtual_routes }}"
+  loop_control:
+    label: "{{ item.dest }}"
+
 - name: assert_instances | Test item in instance.unicast_src_ip
   ansible.builtin.assert:
     that:

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -1,5 +1,16 @@
 {{ ansible_managed | comment }}
+{% if keepalived_global_defs is defined %}
 
+global_defs {
+{% if keepalived_global_defs.enable_script_security is defined and keepalived_global_defs.enable_script_security %}
+  enable_script_security
+{% endif %}
+{% if keepalived_global_defs.script_user is defined and keepalived_global_defs.enable_script_security %}
+  script_user {{  keepalived_global_defs.script_user }}
+{% endif %}
+}
+
+{% endif %}
 {% for instance in keepalived_vrrp_instances %}
 {% if instance.check_status_command is defined %}
 
@@ -33,6 +44,26 @@ vrrp_instance {{ instance.name }} {
   track_script {
     chk_command_{{ instance.virtual_router_id }}
 }
+{% endif %}
+{% if instance.virtual_routes is defined %}
+
+  virtual_routes {
+{% for virtual_route in instance.virtual_routes %}
+{% if virtual_route.via is defined %}
+    {{ virtual_route.dest }} via {{ virtual_route.via }} src {{ virtual_route.src }} dev {{ virtual_route.dev }}
+{% elif virtual_route.via is not defined %}
+    {{ virtual_route.dest }} src {{ virtual_route.src }} dev {{ virtual_route.dev }}
+{% endif %}
+{% endfor %}
+  }
+{% endif %}
+{% if instance.notify_master is defined %}
+
+  notify_master {{ instance.notify_master }}
+{% endif %}{% if instance.notify_backup is defined %}
+  notify_backup {{ instance.notify_backup }}
+{% endif %}{% if instance.notify_stop is defined %}
+  notify_stop {{ instance.notify_stop }}
 {% endif %}
 }
 {% endfor %}


### PR DESCRIPTION
---
name: Pull request
about: Initial support for global_defs, virtual_routes, and notify_* scripts

---
Greetings,
I found myself needing support for a couple of extra features.  This PR does three things.  It adds initial support for global_defs in the keepalived.conf file.  It also adds support for virtual_routes under the existing vrrp instance.  Finally it adds support for the notify_master, notify_backup, and notify_stop elements.

Please note that the global_defs only supports the "enable_script_security" and  "script_user" fields.  For virtual routes, I think I correctly added support for an optional "via" field.  Regarding the notify_* fields, I only added support for the entire line.  

I attempted to match your coding style in the templates/keepalived.conf.j2 file.

Please advise if you need any additional changes to this PR.

Thanks for the work you do, I hope this PR is helpful.

**Testing**
I updated assert.yml and assert_instances.yml to test for these new fields.  Additionally, I added the new fields to the converge.yml to test these new features. 

I manually ran molecule test for the default, ubuntu, and alpine images.  


