### PR TITLE
Fix check_command usage with option to add global_defs. Add check_command_opts to configure extra options for check_command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ The default values for the variables are set in [`defaults/main.yml`](https://gi
 #     priority: 255
 #   # `check_status_command` will make +3 to priority if command return is 0 (optional). example:
 #     check_status_command: /sbin/postfix status
+#   # `check_status_interval` interval for status check (defaults to 2 seconds)
+#     check_status_interval: 2
+#   # `check_status_weight`: weight to add in status check (default to 3)
+#     check_status_weight: 3
+#   # `check_status_opts`: extra opts to add to status check defaults
+#     check_status_opts:
+#       rise: 2
+#       fall: 2
 #   # `authentication` specifies the information necessary for servers participating in VRRP to authenticate with each other.
 #     authentication:
 #       auth_type: PASS

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ This example is taken from [`molecule/default/converge.yml`](https://github.com/
           virtual_ipaddresses:
             - name: "172.17.0.8"
               cidr: 16
+      keepalived_global_defs:
+        enable_script_security: ~
+        script_user: root
 ```
 
 The machine needs to be prepared. In CI this is done using [`molecule/default/prepare.yml`](https://github.com/robertdebock/ansible-role-keepalived/blob/master/molecule/default/prepare.yml):
@@ -103,6 +106,15 @@ The default values for the variables are set in [`defaults/main.yml`](https://gi
 #       - name: "192.168.122.200"
 #         cidr: 24
 keepalived_vrrp_instances: []
+
+# keepalived_global_defs:
+# Configure optional key-value pairs here. for global definitions. E.g. required for adding scripts usage in newer keepalived versions.
+# Meant to be generic as possible. Can also accept keys without values.
+# Example:
+# keepalived_globals_defs:
+#  enable_script_security: ~  # <- This will not add an value after the key. E.g. the yaml null variable ~ is used
+#  script_user: root
+keepalived_global_defs: {}
 ```
 
 ## [Requirements](#requirements)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,3 +46,12 @@
 #       - name: "192.168.122.200"
 #         cidr: 24
 keepalived_vrrp_instances: []
+
+# keepalived_global_defs:
+# Configure optional key-value pairs here. for global definitions. E.g. required for adding scripts usage in newer keepalived versions.
+# Meant to be generic as possible. Can also accept keys without values.
+# Example:
+# keepalived_globals_defs:
+#  enable_script_security: ~  # <- This will not add an value after the key. E.g. the yaml null variable ~ is used
+#  script_user: root
+keepalived_global_defs: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,14 @@
 #     priority: 255
 #   # `check_status_command` will make +3 to priority if command return is 0 (optional). example:
 #     check_status_command: /sbin/postfix status
+#   # `check_status_interval` interval for status check (defaults to 2 seconds)
+#     check_status_interval: 2
+#   # `check_status_weight`: weight to add in status check (default to 3)
+#     check_status_weight: 3
+#   # `check_status_opts`: extra opts to add to status check defaults
+#     check_status_opts:
+#       rise: 2
+#       fall: 2
 #   # `authentication` specifies the information necessary for servers participating in VRRP to authenticate with each other.
 #     authentication:
 #       auth_type: PASS

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,8 @@
   ansible.builtin.template:
     src: keepalived.conf.j2
     dest: /etc/keepalived/keepalived.conf
+    trim_blocks: true
+    lstrip_blocks: true
     mode: "0640"
     validate: keepalived --config-test --use-file=%s
   notify:

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -3,8 +3,9 @@
 {% if keepalived_global_defs is defined and keepalived_global_defs %}
 global_defs {
   {% for opt_name, opt_value in keepalived_global_defs.items() %}
-    {{ opt_name }}{% if opt_value %}{{ opt_value }}{% endif %}
+    {{ opt_name }}{% if opt_value %} {{ opt_value }}{% endif %}
   {% endfor %}
+
 }
 {% endif %}
 

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -19,7 +19,7 @@ vrrp_script chk_command_{{ instance.virtual_router_id }} {
    interval {{ instance.check_status_interval | default(2) }}          # (default) check every 2 seconds
    weight {{ instance.check_status_weight | default(3) }}              # (default) add 3 points of prio if OK
    {% if instance.check_status_opts is defined and instance.check_status_opts %}
-   {% for opt_name, opt_value in instance.check_status_opts.items() | default(omit) %}
+   {% for opt_name, opt_value in instance.check_status_opts.items() %}
    {{ opt_name }} {{ opt_value }}
    {% endfor %}
    {% endif %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -1,6 +1,6 @@
 {{ ansible_managed | comment }}
 
-{% if keepalived_global_defs %}
+{% if keepalived_global_defs is defined and keepalived_global_defs %}
 global_defs {
 {% for opt_name, opt_value in keepalived_global_defs.values() %}
   {{ opt_name }}{% if opt_value %}{{ opt_value }}{% endif %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -2,9 +2,9 @@
 
 {% if keepalived_global_defs is defined and keepalived_global_defs %}
 global_defs {
-{% for opt_name, opt_value in keepalived_global_defs.items() %}
-  {{ opt_name }}{% if opt_value %}{{ opt_value }}{% endif %}
-{% endfor %}
+  {% for opt_name, opt_value in keepalived_global_defs.items() %}
+    {{ opt_name }}{% if opt_value %}{{ opt_value }}{% endif %}
+  {% endfor %}
 }
 {% endif %}
 

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -15,7 +15,7 @@ vrrp_script chk_command_{{ instance.virtual_router_id }} {
    script "{{ instance.check_status_command }}"   # command that verify status
    interval {{ instance.check_status_interval | default(2) }}          # (default) check every 2 seconds
    weight {{ instance.check_status_weight | default(3) }}              # (default) add 3 points of prio if OK
-   {% if instance.check_status_opts %}
+   {% if instance.check_status_opts is defined and instance.check_status_opts %}
    {% for opt_name, opt_value in instance.check_status_opts.values() | default(omit) %}
    {{ opt_name }} {{ opt_value }}
    {% endfor %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -4,9 +4,14 @@
 {% if instance.check_status_command is defined %}
 
 vrrp_script chk_command_{{ instance.virtual_router_id }} {
-   script "{{ instance.check_status_command }} "   # command that verify status 
-   interval 2                    # check every 2 seconds
-   weight 3                      # add 3 points of prio if OK
+   script "{{ instance.check_status_command }}"   # command that verify status
+   interval {{ instance.check_status_interval | default(2) }}          # (default) check every 2 seconds
+   weight {{ instance.check_status_weight | default(3) }}              # (default) add 3 points of prio if OK
+   {% if instance.check_status_opts %}
+   {% for opt_name, opt_value in instance.check_status_opts.values() | default(omit) %}
+   {{ opt_name }} {{ opt_value }}
+   {% endfor %}
+   {% endif %}
 }
 
 {% endif %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -3,7 +3,7 @@
 {% if keepalived_global_defs %}
 global_defs {
 {% for opt_name, opt_value in keepalived_global_defs.values() %}
-  {{ opt_name }} {{ opt_value }}
+  {{ opt_name }}{% if opt_value %}{{ opt_value }}{% endif %}
 {% endfor %}
 }
 {% endif %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -1,5 +1,13 @@
 {{ ansible_managed | comment }}
 
+{% if keepalived_global_defs %}
+global_defs {
+{% for opt_name, opt_value in keepalived_global_defs.values() %}
+  {{ opt_name }} {{ opt_value }}
+{% endfor %}
+}
+{% endif %}
+
 {% for instance in keepalived_vrrp_instances %}
 {% if instance.check_status_command is defined %}
 

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -43,12 +43,12 @@ vrrp_instance {{ instance.name }} {
   virtual_ipaddress {
   {% for ip in instance.virtual_ipaddresses %}
   {{ ip.name }}/{{ ip.cidr }}
-{% endfor %}
+  {% endfor %}
   }
 {% if instance.check_status_command is defined %}
   track_script {
     chk_command_{{ instance.virtual_router_id }}
-}
+  }
 {% endif %}
 }
 {% endfor %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -42,7 +42,7 @@ vrrp_instance {{ instance.name }} {
   }
   virtual_ipaddress {
   {% for ip in instance.virtual_ipaddresses %}
-  {{ ip.name }}/{{ ip.cidr }}
+    {{ ip.name }}/{{ ip.cidr }}
   {% endfor %}
   }
 {% if instance.check_status_command is defined %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -19,7 +19,7 @@ vrrp_script chk_command_{{ instance.virtual_router_id }} {
    {% for opt_name, opt_value in instance.check_status_opts.values() | default(omit) %}
    {{ opt_name }} {{ opt_value }}
    {% endfor %}
-   {% endif -%}
+   {% endif %}
 }
 
 {% endif %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -2,7 +2,7 @@
 
 {% if keepalived_global_defs is defined and keepalived_global_defs %}
 global_defs {
-{% for opt_name, opt_value in keepalived_global_defs.values() %}
+{% for opt_name, opt_value in keepalived_global_defs.items() %}
   {{ opt_name }}{% if opt_value %}{{ opt_value }}{% endif %}
 {% endfor %}
 }
@@ -16,7 +16,7 @@ vrrp_script chk_command_{{ instance.virtual_router_id }} {
    interval {{ instance.check_status_interval | default(2) }}          # (default) check every 2 seconds
    weight {{ instance.check_status_weight | default(3) }}              # (default) add 3 points of prio if OK
    {% if instance.check_status_opts is defined and instance.check_status_opts %}
-   {% for opt_name, opt_value in instance.check_status_opts.values() | default(omit) %}
+   {% for opt_name, opt_value in instance.check_status_opts.items() | default(omit) %}
    {{ opt_name }} {{ opt_value }}
    {% endfor %}
    {% endif %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -3,7 +3,9 @@
 {% if keepalived_global_defs is defined and keepalived_global_defs %}
 global_defs {
   {% for opt_name, opt_value in keepalived_global_defs.items() %}
-    {{ opt_name }}{% if opt_value %} {{ opt_value }}{% endif %}
+  {{ opt_name }}{% if opt_value %} {{ opt_value }}{% endif %}{% if not loop.last %}
+
+  {% endif %}
   {% endfor %}
 
 }

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -19,7 +19,7 @@ vrrp_script chk_command_{{ instance.virtual_router_id }} {
    {% for opt_name, opt_value in instance.check_status_opts.values() | default(omit) %}
    {{ opt_name }} {{ opt_value }}
    {% endfor %}
-   {% endif %}
+   {% endif -%}
 }
 
 {% endif %}


### PR DESCRIPTION
---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
A clear and concise description of what the pull request is.

Add new dictionary `keepalived_global_defs` to configure global defs.

Add `check_command_opts` to add extra options to the vrrp_script part.

Only "breaking" change is formatting of j2 templates. I always use lstrip_block and trim_blocks to true, because it is easier to manage indendations that way. So if you rerun it on your older setup with check mode you might see changes to where brackets are located, but this is for the better.

**Testing**
In case a feature was added, how were tests performed?

Ran on my Debian infrastructure ansible. With old config that was not working and then with new opts. It is backwards compatible and does not introduce anything breaking.

Fixes: #6 